### PR TITLE
Add .gitignore and update app.py to sync to frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+__pycache__/
+env/

--- a/app.py
+++ b/app.py
@@ -1,16 +1,35 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, send_from_directory
 from flask_cors import CORS
 from api.routes import api  # Import the Blueprint
+import os
 
-app = Flask(__name__)
-CORS(app, resources={r"/api/*": {"origins": "http://localhost:5173"}})  # Vite runs on 5173
+# Initialize Flask app
+app = Flask(
+    __name__,
+    static_folder=os.path.join(os.getcwd(), "../redback-fit-web"),  # Move one level up and access redback-fit-web
+    static_url_path="/"  # Serve files from the root URL
+)
+
+# Set up CORS for development purposes
+CORS(app, resources={r"/api/*": {"origins": "http://localhost:5173"}})  # Vite runs on port 5173
 
 # Register the API Blueprint
 app.register_blueprint(api, url_prefix='/api')
 
+# Example API route
 @app.route('/api/hello', methods=['GET'])
 def hello():
     return jsonify({'message': 'Hello from Flask!'}), 200
 
+# Serve the frontend (index.html)
+@app.route("/")
+def home():
+    try:
+        return send_from_directory(app.static_folder, "index.html")
+    except FileNotFoundError:
+        return jsonify({"error": "index.html not found in the static folder"}), 404
+
 if __name__ == '__main__':
-    app.run(debug=True, port=5000)
+    # Allow dynamic port configuration for flexibility
+    port = int(os.environ.get("PORT", 5000))
+    app.run(debug=True, port=port)


### PR DESCRIPTION
.gitignore makes sure we aren't bringing in cached python files and locally built environments from testing.
The updates to app.py enabling to frontend home directory index.html. Testing API is still enabled and it is able to host index.html from frontend.