### PR TITLE
Created Dashboard Endpoint and Registered Blueprint. Update README with .env Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,23 @@ Backend API for Redback Project 3 (Wearables for athletes), built with Python an
     ```env
     FLASK_ENV=development
     FLASK_APP=app.py
-    SECRET_KEY=SECRET_KEY
+    SECRET_KEY=your-secret-key-here  # ⚠️ Change this to a strong, unique value before deploying to production
     DATABASE_URL=sqlite:///your_database.db
     PORT=5000
+
+    # Firebase Configuration
+    FIREBASE_API_KEY=your-api-key
+    FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+    FIREBASE_PROJECT_ID=your-project-id
+    FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+    FIREBASE_MESSAGING_SENDER_ID=your-messaging-sender-id
+    FIREBASE_APP_ID=your-app-id
+    FIREBASE_MEASUREMENT_ID=your-measurement-id
+    FIREBASE_DATABASE_URL=https://your-project.firebaseio.com
+    FIREBASE_CREDENTIALS_PATH=path/to/your/firebase/credentials.json
     ```
+
+    > ⚠️ Do not commit your `.env` file or Firebase credentials to version control. Add these files to your `.gitignore`.
 
 7. Run the Flask server  
     ```bash

--- a/README.md
+++ b/README.md
@@ -39,10 +39,19 @@ Backend API for Redback Project 3 (Wearables for athletes), built with Python an
     pip install -r requirements.txt
     ```
 
-6. Run the Flask server  
+6. Create a `.env` file in the project root with the following content:
+    ```env
+    FLASK_ENV=development
+    FLASK_APP=app.py
+    SECRET_KEY=SECRET_KEY
+    DATABASE_URL=sqlite:///your_database.db
+    PORT=5000
+    ```
+
+7. Run the Flask server  
     ```bash
     python app.py
     ```
+
 Once running, the backend will be available at:  
 `http://localhost:5000`
-

--- a/api/dashboard.py
+++ b/api/dashboard.py
@@ -1,0 +1,40 @@
+# will require edits to the frontend to ensure user data persists:
+                            # src/components/DashboardLanding/DashboardLanding.tsx
+                            # src/components/ProfileAvatar/ProfileAvatar.tsx
+# alternatively, find edited files on planner board > 'Add Endpoint for the Dashboard'.
+import sys
+
+from flask import Blueprint, jsonify
+from models.user import db, UserProfile
+from flask_cors import CORS
+from datetime import datetime, timezone
+
+# Create the Blueprint for dashboard
+dashboard_bp = Blueprint('dashboard', __name__, url_prefix='/api/dashboard')
+
+# Dashboard Endpoints #
+
+# Endpoint to get the user's dashboard data, including profile info and metrics like VO2 Max
+@dashboard_bp.route('', methods=['GET'])
+def get_dashboard_data():
+    user_id = 1  # Temporary fixed user
+    user = UserProfile.query.filter_by(id=user_id).first()
+
+    if user:
+        current_utc_time = datetime.now(timezone.utc)
+        vo2_max = 45
+
+        # DEBUG LOGGING
+        print(f"User fetched: {user.as_dict()}", file=sys.stderr)
+
+        return jsonify({
+            'name': user.name,
+            'account': user.account,
+            'birthDate': user.birthDate,
+            'gender': user.gender,
+            'avatar': user.avatar,
+            'lastLogin': current_utc_time.isoformat(),
+            'vo2Max': vo2_max
+        })
+
+    return jsonify({'message': 'User not found'}), 404

--- a/api/dashboard.py
+++ b/api/dashboard.py
@@ -22,7 +22,7 @@ def get_dashboard_data():
 
     if user:
         current_utc_time = datetime.now(timezone.utc)
-        vo2_max = 45
+        vo2_max = 45 # placeholder for further implementation
 
         # DEBUG LOGGING
         print(f"User fetched: {user.as_dict()}", file=sys.stderr)

--- a/app.py
+++ b/app.py
@@ -80,4 +80,4 @@ def hello():
     return jsonify({'message': 'Hello from Flask!'}), 200
 
 if __name__ == '__main__':
-    app.run(debug=True, port=int(os.getenv("PORT", 5000)))
+    app.run(debug=False, port=int(os.getenv("PORT", 5000)))

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from flask_cors import CORS
 from api.routes import api
 from api.profile import api as profile_api
 from api.goals import goals_bp
+from api.dashboard import dashboard_bp 
 from models.user import db, add_default_user
 from dotenv import load_dotenv
 import os
@@ -39,6 +40,7 @@ db.init_app(app)
 app.register_blueprint(api, url_prefix='/api')
 app.register_blueprint(profile_api, url_prefix='/api/profile')
 app.register_blueprint(goals_bp, url_prefix='/api/goals')
+app.register_blueprint(dashboard_bp, url_prefix='/api/dashboard')
 
 with app.app_context():
     db.create_all()


### PR DESCRIPTION
This PR adds backend support for displaying persistent user information on the dashboard.
It also edits the README with instructions for .env setup.

- Created dashboard.py with a new API endpoint to serve user data for the dashboard
-  Registered the dashboard blueprint in app.py.

These updates enable frontend components (DashboardLanding.tsx and ProfileAvatar.tsx) to retrieve the user's name and profile image from the backend.
Frontend instructions and edited files are available on the planner board card.

