### PR TITLE
Add dashboard endpoint

### DIFF
--- a/api/dashboard.py
+++ b/api/dashboard.py
@@ -1,0 +1,40 @@
+# will require edits to the frontend to ensure user data persists:
+                            # src/components/DashboardLanding/DashboardLanding.tsx
+                            # src/components/ProfileAvatar/ProfileAvatar.tsx
+# alternatively, find edited files on planner board > 'Add Endpoint for the Dashboard'.
+import sys
+
+from flask import Blueprint, jsonify
+from models.user import db, UserProfile
+from flask_cors import CORS
+from datetime import datetime, timezone
+
+# Create the Blueprint for dashboard
+dashboard_bp = Blueprint('dashboard', __name__, url_prefix='/api/dashboard')
+
+# Dashboard Endpoints #
+
+# Endpoint to get the user's dashboard data, including profile info and metrics like VO2 Max
+@dashboard_bp.route('', methods=['GET'])
+def get_dashboard_data():
+    user_id = 1  # Temporary fixed user
+    user = UserProfile.query.filter_by(id=user_id).first()
+
+    if user:
+        current_utc_time = datetime.now(timezone.utc)
+        vo2_max = 45 # placeholder for further implementation
+
+        # DEBUG LOGGING
+        print(f"User fetched: {user.as_dict()}", file=sys.stderr)
+
+        return jsonify({
+            'name': user.name,
+            'account': user.account,
+            'birthDate': user.birthDate,
+            'gender': user.gender,
+            'avatar': user.avatar,
+            'lastLogin': current_utc_time.isoformat(),
+            'vo2Max': vo2_max
+        })
+
+    return jsonify({'message': 'User not found'}), 404

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from flask_cors import CORS
 from api.routes import api
 from api.profile import api as profile_api
 from api.goals import goals_bp
+from api.dashboard import dashboard_bp 
 from models.user import db, add_default_user
 from dotenv import load_dotenv
 import os
@@ -39,6 +40,7 @@ db.init_app(app)
 app.register_blueprint(api, url_prefix='/api')
 app.register_blueprint(profile_api, url_prefix='/api/profile')
 app.register_blueprint(goals_bp, url_prefix='/api/goals')
+app.register_blueprint(dashboard_bp, url_prefix='/api/dashboard')
 
 with app.app_context():
     db.create_all()
@@ -78,4 +80,4 @@ def hello():
     return jsonify({'message': 'Hello from Flask!'}), 200
 
 if __name__ == '__main__':
-    app.run(debug=True, port=int(os.getenv("PORT", 5000)))
+    app.run(debug=False, port=int(os.getenv("PORT", 5000)))


### PR DESCRIPTION
This PR adds backend support for displaying persistent user information on the dashboard when used with frontend.

Created dashboard.py with a new API endpoint to serve user data for the dashboard

Registered the dashboard blueprint in app.py.

These updates enable frontend components (DashboardLanding.tsx and ProfileAvatar.tsx) to retrieve the user's name and profile image from the backend.

Frontend instructions and edited files are available on the planner board card.