### PR TITLE
Add *.db to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 env/
 .env
 .ipynb_checkpoints/
+*.db


### PR DESCRIPTION
This prevents local SQLite database files from being accidentally committed to the repository. 

Local `.db` files may contain development or user data that shouldn't be shared or versioned and could include sensitive information.